### PR TITLE
alternative method of testing forms with collections

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -789,6 +789,25 @@ You can remove an existing field, e.g. a tag::
     // the tag has been removed
     $this->assertEquals(0, $crawler->filter('ul.tags > li')->count());
 
+You can also manipulate the DOM before obtaining the form - this can be useful for simulating collections. For example,
+if you had a form which could include dynamic upload fields, you can add the extra fields to the DOM before obtaining
+the form::
+
+    // create dynamic file input element in same document
+    $input = $crawler->getNode(0)->ownerDocument->createElement('input');
+    $input->setAttribute('type', 'file');
+    $input->setAttribute('name', 'my_entity[images][0][newImage]');
+    
+    // get the form node by name and add our new element to it
+    $crawler->filter('form[name="form_name"]')->getNode(0)->appendChild($input);
+    
+    // get the form as normal
+    $form = $crawler->selectButton('Update')->form();
+    
+    // now we can do things like this...
+    $form['my_entity[images][0][newImage]']->upload($filename);
+
+
 .. index::
    pair: Tests; Configuration
 


### PR DESCRIPTION
As suggested in https://github.com/symfony/symfony/issues/4124#issuecomment-431594398 this outlines how forms which have dynamic collections can be simulated by manipulating the DOM before obtaining the Form object

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
